### PR TITLE
fix:allow workshop 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ovos-workshop>=0.0.15,<3.0.0
+ovos-workshop>=0.0.15,<4.0.0
 
 ovos-date-parser>=0.0.1,<1.0.0
 ovos-number-parser>=0.0.1,<1.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos-workshop` package, allowing for newer versions up to below 4.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->